### PR TITLE
Allow longer MQTT username and password

### DIFF
--- a/MQTTDevice4.ino
+++ b/MQTTDevice4.ino
@@ -104,8 +104,8 @@ unsigned char addressesFound[NUMBEROFSENSORSMAX][8];
 #define DEF_DELAY_IND 120000 // Standard Nachlaufzeit nach dem Ausschalten Induktionskochfeld
 
 #define maxHostSign 20
-#define maxUserSign 10
-#define maxPassSign 10
+#define maxUserSign 35
+#define maxPassSign 35
 char mqtthost[maxHostSign]; // MQTT Server
 char mqttuser[maxUserSign];
 char mqttpass[maxPassSign];


### PR DESCRIPTION
Hi, 

I just noticed that the username and password in my configuration were cut off at 10 characters. I don't know if there is a specific reason for this limitation so I just increased the maximum length to 35.

@InnuendoPi, what do you think?

Thanks!
Philipp